### PR TITLE
switch back to scala 2.12.0. this fixes #2

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,7 +1,7 @@
 name := "signal-desktop-client"
 version := "0.0.1"
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.12.0"
 test in assembly := {}
 fork := true
 


### PR DESCRIPTION
as scalafxml is now cross-built for scala 2.12 :)

fixes #2 