### PR TITLE
restructure accounthelper

### DIFF
--- a/src/main/scala/de/m7w3/signal/account/AccountHelper.scala
+++ b/src/main/scala/de/m7w3/signal/account/AccountHelper.scala
@@ -1,22 +1,20 @@
 package de.m7w3.signal.account
 
-import de.m7w3.signal.store.SignalDesktopProtocolStore
-import org.whispersystems.libsignal.state.{PreKeyRecord, SignedPreKeyRecord}
+import de.m7w3.signal.messages.MessageSender
+import de.m7w3.signal.store.model.Registration
 
-trait AccountHelper {
-  def generateNewDeviceURL(): String
-  def finishDeviceLink(deviceName: String, store: SignalDesktopProtocolStore): Unit
-  def refreshPreKeys(store: SignalDesktopProtocolStore): PreKeyRefreshResult
+trait AccountHelper extends PreKeyRefresher {
   def countAvailablePreKeys(): Int
+  def requestSyncGroups(): Unit
+  def requestSyncContacts(): Unit
 }
-
-case class PreKeyRefreshResult(oneTimePreKeys: List[PreKeyRecord], lastResortKey: PreKeyRecord, signedPreKeyRecord: SignedPreKeyRecord)
-
 
 object AccountHelper {
-  val PREKEY_BATCH_SIZE = 100
-
-  def apply(userId: String, password: String): AccountHelper = {
-    AccountHelperImpl(userId, password)
+  def apply(registration: Registration, messageSender: MessageSender): AccountHelper = {
+    AccountHelperImpl(registration.userName, registration.password, registration.deviceId, messageSender)
   }
 }
+
+
+
+

--- a/src/main/scala/de/m7w3/signal/account/AccountHelperImpl.scala
+++ b/src/main/scala/de/m7w3/signal/account/AccountHelperImpl.scala
@@ -1,76 +1,38 @@
 package de.m7w3.signal.account
 
 import java.io.IOException
-import java.net.URLEncoder
-import java.security.InvalidKeyException
 
 import de.m7w3.signal._
-import de.m7w3.signal.store.SignalDesktopProtocolStore
-import de.m7w3.signal.store.model.Identity
-import org.whispersystems.libsignal.IdentityKeyPair
-import org.whispersystems.libsignal.ecc.Curve
-import org.whispersystems.libsignal.state.{PreKeyRecord, SignedPreKeyRecord}
-import org.whispersystems.libsignal.util.guava.Optional
-import org.whispersystems.libsignal.util.{KeyHelper, Medium}
+import de.m7w3.signal.messages.MessageSender
+import org.whispersystems.signalservice.api.SignalServiceAccountManager
 import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException
 import org.whispersystems.signalservice.api.messages.multidevice.{RequestMessage, SignalServiceSyncMessage}
-import org.whispersystems.signalservice.api.{SignalServiceAccountManager, SignalServiceMessageSender}
 import org.whispersystems.signalservice.internal.push.SignalServiceProtos
-import org.whispersystems.signalservice.internal.util.Base64
 
-import scala.util.{Success, Try}
 
-/**
-  * Created by mat on 16.02.17.
-  */
-case class AccountHelperImpl(userId: String, password: String) extends AccountHelper with Logging {
+private[account] case class AccountHelperImpl(userId: String, password: String, deviceId: Int, messageSender: MessageSender)
+  extends PreKeyRefresher
+    with AccountHelper
+    with Logging {
 
-  val accountManager = new SignalServiceAccountManager(Constants.SERVICE_URLS, userId, password, Constants.USER_AGENT)
-
-  override def generateNewDeviceURL(): String = {
-    val uuid = URLEncoder.encode(accountManager.getNewDeviceUuid, "UTF-8")
-    val publicKey = URLEncoder.encode(Base64.encodeBytesWithoutPadding(TemporaryIdentity.get.getPublicKey.serialize()), "UTF-8")
-    val url = s"tsdevice:/?uuid=$uuid&pub_key=$publicKey"
-    url
-  }
-
-  override def finishDeviceLink(deviceName: String, store: SignalDesktopProtocolStore): Unit = {
-      val signalingKey = Util.getSecret(52)
-      val temporaryRegistrationId = KeyHelper.generateRegistrationId(false)
-      val ret = accountManager.finishNewDeviceRegistration(TemporaryIdentity.get, signalingKey, false, true, temporaryRegistrationId, deviceName)
-      val deviceId = ret.getDeviceId
-      val username = ret.getNumber
-      val identity = Identity(temporaryRegistrationId, ret.getIdentity.serialize())
-      store.identityKeyStore.initialize(identity)
-      store.save(username, deviceId, password, signalingKey)
-
-      refreshPreKeys(store)
-      requestSyncGroups(deviceId, store)
-      requestSyncContacts(deviceId, store)
-  }
-
-  override def refreshPreKeys(store: SignalDesktopProtocolStore): PreKeyRefreshResult = {
-    import scala.collection.JavaConverters.seqAsJavaListConverter
-
-    val oneTimePreKeys = generatePreKeys(store)
-    val lastResortKey = getOrGenerateLastResortPreKey(store)
-    val signedPreKeyRecord = generateSignedPreKey(store.getIdentityKeyPair(), store)
-
-    accountManager.setPreKeys(store.getIdentityKeyPair().getPublicKey, lastResortKey, signedPreKeyRecord, oneTimePreKeys.asJava)
-    PreKeyRefreshResult(oneTimePreKeys, lastResortKey, signedPreKeyRecord)
-  }
+  val accountManager: SignalServiceAccountManager = new SignalServiceAccountManager(
+    Constants.SERVICE_URLS,
+    userId,
+    password,
+    deviceId,
+    Constants.USER_AGENT
+  )
 
   override def countAvailablePreKeys(): Int = {
     accountManager.getPreKeysCount
   }
 
   @throws[IOException]
-  private def requestSyncGroups(deviceId: Int, store: SignalDesktopProtocolStore) {
+  override def requestSyncGroups(): Unit = {
     val r = SignalServiceProtos.SyncMessage.Request.newBuilder.setType(SignalServiceProtos.SyncMessage.Request.Type.GROUPS).build
     val message = SignalServiceSyncMessage.forRequest(new RequestMessage(r))
     try
-      sendSyncMessage(message, deviceId, store)
-
+      messageSender.send(message)
     catch {
       case e: UntrustedIdentityException => {
         logger.error("Error requesting group synchronization", e)
@@ -79,79 +41,15 @@ case class AccountHelperImpl(userId: String, password: String) extends AccountHe
   }
 
   @throws[IOException]
-  private def requestSyncContacts(deviceId: Int, store: SignalDesktopProtocolStore) {
+  override def requestSyncContacts(): Unit = {
     val r = SignalServiceProtos.SyncMessage.Request.newBuilder.setType(SignalServiceProtos.SyncMessage.Request.Type.CONTACTS).build
     val message = SignalServiceSyncMessage.forRequest(new RequestMessage(r))
     try
-      sendSyncMessage(message, deviceId, store)
-
+      messageSender.send(message)
     catch {
       case e: UntrustedIdentityException => {
         logger.error("Error requesting contact synchronization", e)
       }
-    }
-  }
-
-  @throws[IOException]
-  @throws[UntrustedIdentityException]
-  private def sendSyncMessage(message: SignalServiceSyncMessage,
-                              deviceId: Int,
-                              store: SignalDesktopProtocolStore) {
-    val messageSender = new SignalServiceMessageSender(
-      Constants.SERVICE_URLS,
-      userId,
-      password,
-      deviceId,
-      store,
-      Constants.USER_AGENT,
-      Optional.absent[SignalServiceMessageSender.EventListener])
-    try
-      messageSender.sendMessage(message)
-    catch {
-      case e: UntrustedIdentityException => {
-        logger.error("untrusted identity encountered", e)
-        //store.saveIdentity(e.getE164Number, e.getIdentityKey, TrustLevel.UNTRUSTED)
-        throw e
-      }
-    }
-  }
-
-  def generatePreKeys(store: SignalDesktopProtocolStore): List[PreKeyRecord] = {
-    val records = (0 until AccountHelper.PREKEY_BATCH_SIZE).map(i => {
-      val preKeyId = store.preKeyStore.incrementAndGetPreKeyId()
-      val keyPair = Curve.generateKeyPair()
-      val record = new PreKeyRecord(preKeyId, keyPair)
-      store.storePreKey(preKeyId, record)
-      record
-    })
-    records.toList
-  }
-
-  def getOrGenerateLastResortPreKey(store: SignalDesktopProtocolStore): PreKeyRecord = {
-    Try(store.containsPreKey(Medium.MAX_VALUE)) match {
-      case Success(true) => store.loadPreKey(Medium.MAX_VALUE)
-      case _ => {
-        store.removePreKey(Medium.MAX_VALUE)
-        val keyPair = Curve.generateKeyPair()
-        val record = new PreKeyRecord(Medium.MAX_VALUE, keyPair)
-        store.storePreKey(Medium.MAX_VALUE, record)
-        record
-      }
-    }
-  }
-
-  def generateSignedPreKey(identityKeyPair: IdentityKeyPair, store: SignalDesktopProtocolStore): SignedPreKeyRecord = {
-    try {
-      val nextSignedPreKeyId = store.signedPreKeyStore.getSignedPreKeyId
-      val keyPair = Curve.generateKeyPair()
-      val signature = Curve.calculateSignature(identityKeyPair.getPrivateKey, keyPair.getPublicKey.serialize())
-
-      val record = new SignedPreKeyRecord(nextSignedPreKeyId, System.currentTimeMillis(), keyPair, signature)
-      store.storeSignedPreKey(nextSignedPreKeyId, record)
-      store.signedPreKeyStore.incrementAndGetSignedPreKeyId()
-      record
-    } catch {
-      case e: InvalidKeyException => throw new AssertionError(e)
     }
   }
 }

--- a/src/main/scala/de/m7w3/signal/account/AccountInitializationHelper.scala
+++ b/src/main/scala/de/m7w3/signal/account/AccountInitializationHelper.scala
@@ -1,0 +1,15 @@
+package de.m7w3.signal.account
+
+import de.m7w3.signal.store.SignalDesktopProtocolStore
+import de.m7w3.signal.store.model.Registration
+
+trait AccountInitializationHelper extends PreKeyRefresher{
+  def generateNewDeviceURL(): String
+  def finishDeviceRegistration(deviceName: String, store: SignalDesktopProtocolStore): Registration
+}
+
+object AccountInitializationHelper {
+  def apply(userId: String, password: String): AccountInitializationHelper = {
+    AccountInitializationHelperImpl(userId, password)
+  }
+}

--- a/src/main/scala/de/m7w3/signal/account/AccountInitializationHelperImpl.scala
+++ b/src/main/scala/de/m7w3/signal/account/AccountInitializationHelperImpl.scala
@@ -1,0 +1,41 @@
+package de.m7w3.signal.account
+
+import java.net.URLEncoder
+
+import de.m7w3.signal.store.SignalDesktopProtocolStore
+import de.m7w3.signal.store.model.{Identity, Registration}
+import de.m7w3.signal.{Constants, Logging, TemporaryIdentity, Util}
+import org.whispersystems.libsignal.util.KeyHelper
+import org.whispersystems.signalservice.api.SignalServiceAccountManager
+import org.whispersystems.signalservice.internal.util.Base64
+
+private[account] case class AccountInitializationHelperImpl(userId: String, password: String)
+  extends PreKeyRefresher
+    with AccountInitializationHelper
+    with Logging {
+
+  val accountManager = new SignalServiceAccountManager(Constants.SERVICE_URLS, userId, password, Constants.USER_AGENT)
+
+  override def generateNewDeviceURL(): String = {
+    val uuid = URLEncoder.encode(accountManager.getNewDeviceUuid, "UTF-8")
+    val publicKey = URLEncoder.encode(Base64.encodeBytesWithoutPadding(TemporaryIdentity.get.getPublicKey.serialize()), "UTF-8")
+    val url = s"tsdevice:/?uuid=$uuid&pub_key=$publicKey"
+    url
+  }
+
+  override def finishDeviceRegistration(deviceName: String, store: SignalDesktopProtocolStore): Registration = {
+    val signalingKey = Util.getSecret(52)
+    val temporaryRegistrationId = KeyHelper.generateRegistrationId(false)
+    val ret = accountManager.finishNewDeviceRegistration(TemporaryIdentity.get, signalingKey, false, true, temporaryRegistrationId, deviceName)
+    val deviceId = ret.getDeviceId
+    val userName = ret.getNumber
+    val identity = Identity(temporaryRegistrationId, ret.getIdentity.serialize())
+    store.identityKeyStore.initialize(identity)
+    refreshPreKeys(store)
+
+    val registration = Registration(userName, deviceId, password, signalingKey)
+    store.save(registration)
+    registration
+  }
+
+}

--- a/src/main/scala/de/m7w3/signal/account/PreKeyRefresher.scala
+++ b/src/main/scala/de/m7w3/signal/account/PreKeyRefresher.scala
@@ -1,0 +1,73 @@
+package de.m7w3.signal.account
+
+import java.security.InvalidKeyException
+
+import de.m7w3.signal.store.SignalDesktopProtocolStore
+import org.whispersystems.libsignal.IdentityKeyPair
+import org.whispersystems.libsignal.ecc.Curve
+import org.whispersystems.libsignal.state.{PreKeyRecord, SignedPreKeyRecord}
+import org.whispersystems.libsignal.util.Medium
+import org.whispersystems.signalservice.api.SignalServiceAccountManager
+
+import scala.util.{Success, Try}
+
+case class PreKeyRefreshResult(oneTimePreKeys: List[PreKeyRecord], lastResortKey: PreKeyRecord, signedPreKeyRecord: SignedPreKeyRecord)
+
+trait PreKeyRefresher {
+
+  def accountManager: SignalServiceAccountManager
+
+  def refreshPreKeys(store: SignalDesktopProtocolStore): PreKeyRefreshResult = {
+    import scala.collection.JavaConverters.seqAsJavaListConverter
+
+    val oneTimePreKeys = generatePreKeys(store)
+    val lastResortKey = getOrGenerateLastResortPreKey(store)
+    val signedPreKeyRecord = generateSignedPreKey(store.getIdentityKeyPair(), store)
+
+    accountManager.setPreKeys(store.getIdentityKeyPair().getPublicKey, lastResortKey, signedPreKeyRecord, oneTimePreKeys.asJava)
+    PreKeyRefreshResult(oneTimePreKeys, lastResortKey, signedPreKeyRecord)
+  }
+
+  def generatePreKeys(store: SignalDesktopProtocolStore): List[PreKeyRecord] = {
+    val records = (0 until PreKeyRefresher.PREKEY_BATCH_SIZE).map(i => {
+      val preKeyId = store.preKeyStore.incrementAndGetPreKeyId()
+      val keyPair = Curve.generateKeyPair()
+      val record = new PreKeyRecord(preKeyId, keyPair)
+      store.storePreKey(preKeyId, record)
+      record
+    })
+    records.toList
+  }
+
+  def getOrGenerateLastResortPreKey(store: SignalDesktopProtocolStore): PreKeyRecord = {
+    Try(store.containsPreKey(Medium.MAX_VALUE)) match {
+      case Success(true) => store.loadPreKey(Medium.MAX_VALUE)
+      case _ => {
+        store.removePreKey(Medium.MAX_VALUE)
+        val keyPair = Curve.generateKeyPair()
+        val record = new PreKeyRecord(Medium.MAX_VALUE, keyPair)
+        store.storePreKey(Medium.MAX_VALUE, record)
+        record
+      }
+    }
+  }
+
+  def generateSignedPreKey(identityKeyPair: IdentityKeyPair, store: SignalDesktopProtocolStore): SignedPreKeyRecord = {
+    try {
+      val nextSignedPreKeyId = store.signedPreKeyStore.getSignedPreKeyId
+      val keyPair = Curve.generateKeyPair()
+      val signature = Curve.calculateSignature(identityKeyPair.getPrivateKey, keyPair.getPublicKey.serialize())
+
+      val record = new SignedPreKeyRecord(nextSignedPreKeyId, System.currentTimeMillis(), keyPair, signature)
+      store.storeSignedPreKey(nextSignedPreKeyId, record)
+      store.signedPreKeyStore.incrementAndGetSignedPreKeyId()
+      record
+    } catch {
+      case e: InvalidKeyException => throw new AssertionError(e)
+    }
+  }
+}
+
+object PreKeyRefresher {
+  val PREKEY_BATCH_SIZE = 100
+}

--- a/src/main/scala/de/m7w3/signal/messages/MessageSender.scala
+++ b/src/main/scala/de/m7w3/signal/messages/MessageSender.scala
@@ -1,0 +1,46 @@
+package de.m7w3.signal.messages
+
+import java.io.IOException
+
+import de.m7w3.signal.{Constants, Logging}
+import de.m7w3.signal.store.SignalDesktopProtocolStore
+import de.m7w3.signal.store.model.Registration
+import org.whispersystems.libsignal.util.guava.Optional
+import org.whispersystems.signalservice.api.SignalServiceMessageSender
+import org.whispersystems.signalservice.api.crypto.UntrustedIdentityException
+import org.whispersystems.signalservice.api.messages.multidevice.SignalServiceSyncMessage
+
+trait MessageSender {
+  def send(message: SignalServiceSyncMessage): Unit
+}
+
+case class SignalMessageSender(userId: String, password: String, deviceId: Int, store: SignalDesktopProtocolStore) extends MessageSender with Logging {
+  val messageSender = new SignalServiceMessageSender(
+    Constants.SERVICE_URLS,
+    userId,
+    password,
+    deviceId,
+    store,
+    Constants.USER_AGENT,
+    Optional.absent[SignalServiceMessageSender.EventListener])
+
+  @throws[IOException]
+  @throws[UntrustedIdentityException]
+  def send(message: SignalServiceSyncMessage): Unit = {
+    try
+      messageSender.sendMessage(message)
+    catch {
+      case e: UntrustedIdentityException => {
+        logger.error("untrusted identity encountered", e)
+        //store.saveIdentity(e.getE164Number, e.getIdentityKey, TrustLevel.UNTRUSTED)
+        throw e
+      }
+    }
+  }
+}
+
+object SignalMessageSender {
+  def apply(registration: Registration, store: SignalDesktopProtocolStore): SignalMessageSender = {
+    SignalMessageSender(registration.userName, registration.password, registration.deviceId, store)
+  }
+}

--- a/src/main/scala/de/m7w3/signal/store/SignalDesktopProtocolStore.scala
+++ b/src/main/scala/de/m7w3/signal/store/SignalDesktopProtocolStore.scala
@@ -71,8 +71,7 @@ case class SignalDesktopProtocolStore(dbRunner: DBActionRunner) extends SignalPr
   override def deleteSession(address: SignalProtocolAddress): Unit =
     sessionStore.deleteSession(address)
 
-  def save(userName: String, deviceId: Int, password: String, signalingKey: String): Unit = {
-    val registration = Registration(userName, deviceId, password, signalingKey)
+  def save(registration: Registration): Unit = {
     dbRunner.run(RegistrationData.insert(registration))
     ()
   }

--- a/src/test/scala/de/m7w3/signal/TestMessageSender.scala
+++ b/src/test/scala/de/m7w3/signal/TestMessageSender.scala
@@ -1,0 +1,15 @@
+package de.m7w3.signal
+
+import de.m7w3.signal.messages.MessageSender
+import org.whispersystems.signalservice.api.messages.multidevice.SignalServiceSyncMessage
+
+import scala.collection.mutable
+
+object TestMessageSender extends MessageSender {
+
+  val queue = mutable.Queue.empty[SignalServiceSyncMessage]
+
+  override def send(message: SignalServiceSyncMessage): Unit = {
+    queue += message
+  }
+}

--- a/src/test/scala/de/m7w3/signal/events/SignalDesktopEventDispatcherSpec.scala
+++ b/src/test/scala/de/m7w3/signal/events/SignalDesktopEventDispatcherSpec.scala
@@ -78,6 +78,7 @@ class SignalDesktopEventDispatcherSpec extends FlatSpec
               dispatcher: SignalDesktopEventDispatcher): CancelableFuture[Unit] = {
     events.foreach((event) => {
       dispatcher.publishEvent(event)
+      ()
     })
   }
 


### PR DESCRIPTION
in order to use it with deviceId as soon as we are registered
and right from the start if we start from a registered state

due to two different mechanisms how SignalServiceAccountManager is initialized

before we got 401 responses from some methods in accountManager when starting the app from a registered state loaded from db AND from a freshly registered state. This is fixed hereby.